### PR TITLE
Disable iChat usage tracking.

### DIFF
--- a/beta/index.html
+++ b/beta/index.html
@@ -83,7 +83,7 @@
                 <br>
                 <br>
                 <div id="iChat-messages" class="iChat-messages iChat"></div>
-                <script src="https://legend-of-iphoenix.github.io/iChat/js/iChat.min.js"></script>
+                <script src="https://legend-of-iphoenix.github.io/iChat/js/iChat.min.js?notracking"></script>
                 <div id='pming-home' style='display: none;'>
                     <input id='message-input' class='form-control'><br>
                     <button onclick='sendMessage(document.getElementById("message-input").value);' class='btn btn-primary'>Send Message</button>


### PR DESCRIPTION
iChat uses GA to analyze what sites are using it (this is no secret, it's literally all over the iChat repo).

Adding "?notracking" to the end of the script tag lets you disable this tracking.